### PR TITLE
added hack to insert link into clipboard

### DIFF
--- a/autoload/sprunge.vim
+++ b/autoload/sprunge.vim
@@ -6,7 +6,7 @@
 " Notes:       Much of this code was thiefed from gundo.vim
 " ============================================================================
 
-let s:sprunge = 'curl -s -F "sprunge=<-" http://sprunge.us'
+let s:sprunge = 'curl -s -F "sprunge=<-" http://sprunge.us | xclip -selection clipboard; xclip -o -selection clipboard'
 
 function! sprunge#SprungePostBuffer(line1, line2)"{{{
     let buffer = join(getline(a:line1, a:line2), "\n") . "\n"


### PR DESCRIPTION
hey i added a quick & dirty hack to copy the url to the clipboard. It's very ugly because it does't use vim internal functions and requires xclip.
